### PR TITLE
Make ocaml-usb compile with OCaml 4.06

### DIFF
--- a/src/USB.ml
+++ b/src/USB.ml
@@ -552,7 +552,7 @@ end
    +-----------------------------------------------------------------+ *)
 
 let get_string_descriptor handle ?timeout ?lang_id ~index =
-  let data = Bytes.create 255 in
+  let data = Bytes.to_string (Bytes.create 255) in
   let%lwt lang_id = match lang_id with
     | Some lang_id ->
       Lwt.return lang_id


### PR DESCRIPTION
Installing usb with opam on OCaml 4.06.1+flambda failed:
```
opam install usb                                                            
The following actions will be performed:                                                                                                                   ∗  install usb 1.3.0                                                                                                                                   

=-=- Gathering sources =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[usb] Archive in cache

=-=- Processing actions -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[ERROR] The compilation of usb failed at "./configure".
Processing  1/1: [usb: ocamlfind remove]
#=== ERROR while installing usb.1.3.0 =========================================#
# opam-version 1.2.2
# os           linux
# command      ./configure
# path         /home/blendin/.opam/4.06.1+flambda/build/usb.1.3.0
# compiler     4.06.1+flambda
# exit-code    2
# env-file     /home/blendin/.opam/4.06.1+flambda/build/usb.1.3.0/usb-822-1872ec.env
# stdout-file  /home/blendin/.opam/4.06.1+flambda/build/usb.1.3.0/usb-822-1872ec.out
# stderr-file  /home/blendin/.opam/4.06.1+flambda/build/usb.1.3.0/usb-822-1872ec.err
### stderr ###
# File "/home/dim/sources/oasis/src/oasis/OASISString.ml", line 118, characters 8-26:
# Warning 3: deprecated: String.set
# Use Bytes.set instead.
# File "/home/dim/sources/oasis/src/oasis/OASISString.ml", line 118, characters 8-11:
# Error: This expression has type string but an expression was expected of type
#          bytes



=-=- Error report -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
The following actions failed
  ∗  install usb 1.3.0
No changes have been performed

=-=- usb.1.3.0 troobleshooting =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
=> This package relies on external (system) dependencies that may be missing. `opam depext usb.1.3.0' may help you find the correct installation for
   your system.
```

When installing manually:
```
make                                                                          
./setup-dev.exe -build 
Finished, 0 targets (0 cached) in 00:00:00.
File "examples/_tags", line 3, characters 13-20:
Warning: the tag "pkg_usb" is not used in any flag or dependency declaration, so it will have no effect; it may be a typo. Otherwise you can use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
+ /home/blendin/.opam/4.06.1+flambda/bin/ocamlfind ocamlc -c -g -annot -bin-annot -package lwt.ppx -package lwt.unix -I src -o src/USB.cmo src/USB.ml
File "src/USB.ml", line 234, characters 10-28:
Warning 3: deprecated: module Lwt_sequence
 This module is an implementation detail of Lwt. See
   https://github.com/ocsigen/lwt/issues/361
File "src/USB.ml", line 235, characters 10-28:
Warning 3: deprecated: module Lwt_sequence
 This module is an implementation detail of Lwt. See
   https://github.com/ocsigen/lwt/issues/361
File "src/USB.ml", line 273, characters 20-31:
Warning 3: deprecated: Lwt_unix.execute_job
 Use Lwt_unix.run_job.
File "src/USB.ml", line 568, characters 10-14:
Error: This expression has type bytes but an expression was expected of type
         string
Command exited with code 2.
Compilation unsuccessful after building 7 targets (6 cached) in 00:00:00.
E: Failure("Command ''/home/blendin/.opam/4.06.1+flambda/bin/ocamlbuild' src/libusb_stubs.a src/dllusb_stubs.so src/usb.cma src/usb.cmxa src/usb.a src/usb.cmxs -tag debug' terminated with error code 10")
Makefile:27: recipe for target 'build' failed
make: *** [build] Error 1
```

The proposed change solves that issue. "make test" claims to run through successfully.